### PR TITLE
Fix tags to include PHP version

### DIFF
--- a/.github/workflows/php82.yml
+++ b/.github/workflows/php82.yml
@@ -54,4 +54,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PHP_VERSION }}

--- a/.github/workflows/php83.yml
+++ b/.github/workflows/php83.yml
@@ -54,4 +54,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PHP_VERSION }}


### PR DESCRIPTION
### Description

Published images are always the latest version of PHP (e.g. 8.3). 

### Related issues

Resolves #10 